### PR TITLE
updated to es6 boiiiiiiiiiiiiiiiiiiiiiii

### DIFF
--- a/www/node/node-pokemon/poki/app.js
+++ b/www/node/node-pokemon/poki/app.js
@@ -1,13 +1,13 @@
-var createError = require('http-errors');
-var express = require('express');
-var path = require('path');
-var cookieParser = require('cookie-parser');
-var logger = require('morgan');
+const createError = require('http-errors');
+const express = require('express');
+const path = require('path');
+const cookieParser = require('cookie-parser');
+const logger = require('morgan');
 
-var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
+const indexRouter = require('./routes/index');
+const usersRouter = require('./routes/users');
 
-var app = express();
+const app = express();
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -23,12 +23,12 @@ app.use('/', indexRouter);
 app.use('/users', usersRouter);
 
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
+app.use((req, res, next) => {
   next(createError(404));
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use((err, req, res, next) => {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};


### PR DESCRIPTION
I made these changes because arrow functions are way better and using `var` is totally outdated unless you're hoisting, which you are not. Your execution context does not demand you use var, so just use const instead.

also, why aren't you teahing your students React? React is the meta and you're failing to teach them that.